### PR TITLE
use utf8mb4 instead of utf8

### DIFF
--- a/util/rand.go
+++ b/util/rand.go
@@ -142,7 +142,7 @@ func RdColumnOptions(t string) (options []ast.ColumnOptionType) {
 func RdCharset() string {
 	switch Rd(4) {
 	default:
-		return "utf8"
+		return "utf8mb4"
 	}
 }
 


### PR DESCRIPTION
DM use go-sqlsmith to generate ddl. However TiDB doesn't support utf8mb3 https://github.com/pingcap/tidb/issues/26226, so use utf8mb4 instead