### PR TITLE
use utf8mb4_bin as default collation

### DIFF
--- a/stateflow/walker_ddl.go
+++ b/stateflow/walker_ddl.go
@@ -162,6 +162,10 @@ func (s *StateFlow) walkTableOption(node *ast.CreateTableStmt) {
 		Tp:       ast.TableOptionCharset,
 		StrValue: util.RdCharset(),
 	})
+	node.Options = append(node.Options, &ast.TableOption{
+		Tp:       ast.TableOptionCollate,
+		StrValue: "UTF8MB4_BIN",
+	})
 }
 
 func (s *StateFlow) walkPartition(node *ast.PartitionOptions, column *types.Column) {


### PR DESCRIPTION
set default collation for utf8mb4 since mysql8 and mysql5.7 use different default collation