### PR TITLE
migrate travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   integration-test:
     name: go-sqlsmith
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     services:
       mysql:


### PR DESCRIPTION
The previous CI was using Travis, but it hasn’t been maintained and no longer runs properly.

This PR replaces Travis CI with GitHub Actions. The new workflow replicates the original behavior — running make and make integration-test with Go 1.21 and a MySQL service. The GitHub Actions workflow is located in .`github/workflows/ci.yml`.

This should restore CI coverage for PRs and commits going forward.